### PR TITLE
Small fix on utils.sh

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/Utils.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/Utils.sh
@@ -560,7 +560,7 @@ SetIPstatic()
 	
 	# Get IP-Address
 	declare __IP_ADDRESS
-	__IP_ADDRESS=$(ip -o addr show "${SYNTH_NET_INTERFACES[$__iterator]}" | grep -vi inet6 | cut -d '/' -f1 | awk '{print $NF}' | grep -vi '[a-z]')
+	__IP_ADDRESS=$(ip -o addr show "$__interface" | grep -vi inet6 | cut -d '/' -f1 | awk '{print $NF}' | grep -vi '[a-z]')
 
 	if [ -z "$__IP_ADDRESS" ]; then
 		LogMsg "IP address $__ip did not get assigned to $__interface"
@@ -1668,3 +1668,5 @@ IsFreeSpace()
 	fi
 	return 0
 }
+
+

--- a/WS2012R2/lisa/remote-scripts/ica/Utils.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/Utils.sh
@@ -1673,28 +1673,28 @@ IsFreeSpace()
 
 CheckIPv6()
 {
-	#Check if the number of arguments passed to the function is correct
+	LogMsg "Check if the number of arguments passed to the function is correct"
 	if [ 1 -ne $# ]; then
 		LogMsg "CheckIPv6 accepts 1 argument: IPv6 address"
 		return 100
 	fi
 
-	#Declare var IPv6
+	LogMsg "Declare var IPv6"
 	declare IPv6
 
-	#Assigning var IPv6 the only argument passed to the function
+	LogMsg "Assigning var IPv6 the only argument passed to the function"
 	IPv6=$1
 
-	#Spliting string by colon [:] into an array of strings
+	LogMsg "Spliting string by colon [:] into an array of strings"
 	IFS=':' read -ra IP <<< "$IPv6"
 
-	#Checking if number of groups is less than 8.
-	if [ ${#IP[@]}] -gt 8 ]; then
+	LogMsg "Checking if number of groups is less than 8."
+	if [ ${#IP[@]} -gt 8 ]; then
 		LogMsg "Invalid IPv6 address. Too many groups."
 		return 200
 	fi
 
-	#Iterating through each array
+	LogMsg "Iterating through each array"
 	for group in "${IP[@]}"
 	do
 		#Check if a group is in hexazecimal format
@@ -1716,20 +1716,20 @@ CheckIPv6()
 # $3 == netmask [optional]
 SetIPv6Static()
 {
-	# Check number of args passed to the function
+	LogMsg "Check number of args passed to the function"
 	if [ 2 -gt $# ]; then
 		LogMsg "SetIPv6Static accepts 3 arguments: 1. static IPv6, 2. network interface, 3. netmask [optional]"
 		return 100
 	fi
 	
-	# Checking if the ip param is IPv6 like
+	LogMsg  "Checking if the ip param is IPv6 like"
 	CheckIPv6 "$1"
 	if [ 0 -ne $? ]; then
 		LogMsg "Parameter $1 is not a valid IPv6 address"
 		return 1
 	fi
 
-	# Check if network adapter is working
+	LogMsg "Check if network adapter is working"
 	ip link show "$2" > /dev/null 2>&1
 	if [ 0 -ne $? ]; then
 		LogMsg "Network adapter $2 is not working"
@@ -1747,16 +1747,14 @@ SetIPv6Static()
 	__ip="$1"
 	
 	# Check if netmask is correct. Must be an integer from range [1-128]
-	if [ "$__netmask" -le 0] || [ "$__netmask" -gt 128 ]; then
+	if [ "$__netmask" -le 0 ] || [ "$__netmask" -gt 128 ]; then
 		LogMsg "SetIPv6Static: $__netmask is not a valid netmask"
 		return 3
 	fi
 
 	# Setting ip
-	ip -6 link set "$__interface" down
 	ip -6 addr flush "$__interface"
 	ip -6 addr add "$__ip"/"$__netmask" dev "$__interface"
-	ip -6 link set "$__interface" up
 
 	# Check if command managed to set ip
 	if [ 0 -ne $? ]; then
@@ -1766,12 +1764,12 @@ SetIPv6Static()
 
 	# Checking if there is an ip to the interface in cause
 	declare __IP_ADDRESS
-	__IP_ADDRESS=$(ip -o addr show $__interface | grep -i inet6 | cut -d '/' -f1 | cut -d '6' -f2 | tr -d ' ')
+	__IP_ADDRESS=$(ip -o addr show "$__interface" | grep -i inet6 | cut -d '/' -f1 | cut -d '6' -f2 | tr -d ' ')
 	if [ -z "$__IP_ADDRESS" ]; then
 		LogMsg "IPv6 address $__ip did not get assigned to $__interface"
 		return 3
 	fi
-
+	echo "$__IP_ADDRESS"
 	#Checking if found ipv6 address matches with the one we want to set.
 	if [ "$__IP_ADDRESS" != "$__ip" ]; then
 		LogMsg "New address $__IP_ADDRESS differs from static ipv6 $__ip on interface $__interface"

--- a/WS2012R2/lisa/remote-scripts/ica/Utils.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/Utils.sh
@@ -1669,4 +1669,41 @@ IsFreeSpace()
 	return 0
 }
 
+#Validate that $1 is an IPv6 address
 
+CheckIPv6()
+{
+	#Check if the number of arguments passed to the function is correct
+	if [ 1 -ne $# ]; then
+		LogMsg "CheckIPv6 accepts 1 argument: IPv6 address"
+		return 100
+	fi
+
+	#Declare var IPv6
+	declare IPv6
+
+	#Assigning var IPv6 the only argument passed to the function
+	IPv6=$1
+
+	#Spliting string by colon [:] into an array of strings
+	IFS=':' read -ra IP <<< "$IPv6"
+
+	#Checking if number of groups is less than 8.
+	if [ ${#IP[@]}] -gt 8 ]; then
+		LogMsg "Invalid IPv6 address. Too many groups."
+		return 200
+	fi
+
+	#Iterating through each array
+	for group in "${IP[@]}"
+	do
+		#Check if a group is in hexazecimal format
+		if ! [[ $group =~ ^[0-9a-fA-F]{0,4}$ ]]; then
+			LogMsg "Group \"$group\" is not a valid IPv6 group"
+			return 300
+		fi
+	done
+
+	#Everything OK. Exit
+	return 0
+}


### PR DESCRIPTION
In the setIPstatic function, variable __IP_ADDRESS checks if the ip is set corectly, uses a global variable ${SYNTH_NET_INTERFACES[$__iterator]} instead of local variable $__interface. This can lead to false checking.
